### PR TITLE
Go bigip refactor

### DIFF
--- a/examples/go-bigip_example.go
+++ b/examples/go-bigip_example.go
@@ -2,7 +2,7 @@ package bigip
 
 import (
 	"fmt"
-	// "github.com/scottdware/go-bigip"
+
 	"github.com/ajlitzin/go-bigip"
 )
 

--- a/examples/go-bigip_example.go
+++ b/examples/go-bigip_example.go
@@ -2,7 +2,8 @@ package bigip
 
 import (
 	"fmt"
-	"github.com/scottdware/go-bigip"
+	// "github.com/scottdware/go-bigip"
+	"github.com/ajlitzin/go-bigip"
 )
 
 func main() {

--- a/examples/go-bigip_gtm_example.go
+++ b/examples/go-bigip_gtm_example.go
@@ -3,7 +3,6 @@ package bigip
 import (
 	"fmt"
 
-	// "github.com/scottdware/go-bigip"
 	"github.com/ajlitzin/go-bigip"
 )
 

--- a/examples/go-bigip_gtm_example.go
+++ b/examples/go-bigip_gtm_example.go
@@ -3,7 +3,8 @@ package bigip
 import (
 	"fmt"
 
-	"github.com/scottdware/go-bigip"
+	// "github.com/scottdware/go-bigip"
+	"github.com/ajlitzin/go-bigip"
 )
 
 // Note: Had to call main something different as the package complained main was in LTM's example

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,11 @@ module github.com/ajlitzin/go-bigip
 go 1.12
 
 require (
-	github.com/scottdware/go-bigip v0.0.0-20200408123426-e7003eaa3943
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
+
+replace github.com/ajlitzin/go-bigip => github.com/ajlitzin/go-bigip v0.0.0-20200410181702-c5f2c0fb164f
+
+replace github.com/scottdware/go-bigip => github.com/ajlitzin/go-bigip v0.0.0-20200410181702-c5f2c0fb164f

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
-module github.com/scottdware/go-bigip
+module github.com/ajlitzin/go-bigip
 
 go 1.12
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/scottdware/go-bigip v0.0.0-20200408123426-e7003eaa3943
 	github.com/stretchr/testify v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/scottdware/go-bigip v0.0.0-20200408123426-e7003eaa3943 h1:L9F3IFE7QaED7TOXklGwddA2/MPhW18SKNF9ckXmR38=
+github.com/scottdware/go-bigip v0.0.0-20200408123426-e7003eaa3943/go.mod h1:ElPIUv+P7DTtT71aHpeNomJ4naq2RTvCA8o5gBIru3w=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,7 @@
+github.com/ajlitzin/go-bigip v0.0.0-20200410181702-c5f2c0fb164f/go.mod h1:J3pMVx68owPB06HIBQbqU1LxGgvExY19sWkONG61JJA=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/scottdware/go-bigip v0.0.0-20200408123426-e7003eaa3943 h1:L9F3IFE7QaED7TOXklGwddA2/MPhW18SKNF9ckXmR38=
-github.com/scottdware/go-bigip v0.0.0-20200408123426-e7003eaa3943/go.mod h1:ElPIUv+P7DTtT71aHpeNomJ4naq2RTvCA8o5gBIru3w=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/ltm.go
+++ b/ltm.go
@@ -1800,7 +1800,7 @@ func (b *BigIP) AddVirtualServer(config *VirtualServer) error {
 // GetVirtualServer retrieves a virtual server by name. Returns nil if the virtual server does not exist
 func (b *BigIP) GetVirtualServer(name string) (*VirtualServer, error) {
 	var vs VirtualServer
-	fmt.Printf("check for existing vs %s", name)
+	fmt.Printf("check for existing vs name %s \n", name)
 	err, ok := b.getForEntity(&vs, uriLtm, uriVirtual, name)
 	if err != nil {
 		return nil, err

--- a/ltm.go
+++ b/ltm.go
@@ -1800,7 +1800,6 @@ func (b *BigIP) AddVirtualServer(config *VirtualServer) error {
 // GetVirtualServer retrieves a virtual server by name. Returns nil if the virtual server does not exist
 func (b *BigIP) GetVirtualServer(name string) (*VirtualServer, error) {
 	var vs VirtualServer
-	fmt.Println("check for existing vs")
 	err, ok := b.getForEntity(&vs, uriLtm, uriVirtual, name)
 	if err != nil {
 		return nil, err
@@ -1809,14 +1808,12 @@ func (b *BigIP) GetVirtualServer(name string) (*VirtualServer, error) {
 		return nil, nil
 	}
 
-	fmt.Println("about to get for virtual server profiles")
 	profiles, err := b.VirtualServerProfiles(name)
 	if err != nil {
 		return nil, err
 	}
 	vs.Profiles = profiles.Profiles
 
-	fmt.Println("about to get for virtual policies")
 	policy_names, err := b.VirtualServerPolicyNames(name)
 	if err != nil {
 		return nil, err

--- a/ltm.go
+++ b/ltm.go
@@ -1800,6 +1800,7 @@ func (b *BigIP) AddVirtualServer(config *VirtualServer) error {
 // GetVirtualServer retrieves a virtual server by name. Returns nil if the virtual server does not exist
 func (b *BigIP) GetVirtualServer(name string) (*VirtualServer, error) {
 	var vs VirtualServer
+	fmt.Println("check for existing vs")
 	err, ok := b.getForEntity(&vs, uriLtm, uriVirtual, name)
 	if err != nil {
 		return nil, err
@@ -1808,12 +1809,14 @@ func (b *BigIP) GetVirtualServer(name string) (*VirtualServer, error) {
 		return nil, nil
 	}
 
+	fmt.Println("about to get for virtual server profiles")
 	profiles, err := b.VirtualServerProfiles(name)
 	if err != nil {
 		return nil, err
 	}
 	vs.Profiles = profiles.Profiles
 
+	fmt.Println("about to get for virtual policies")
 	policy_names, err := b.VirtualServerPolicyNames(name)
 	if err != nil {
 		return nil, err

--- a/ltm.go
+++ b/ltm.go
@@ -1800,7 +1800,7 @@ func (b *BigIP) AddVirtualServer(config *VirtualServer) error {
 // GetVirtualServer retrieves a virtual server by name. Returns nil if the virtual server does not exist
 func (b *BigIP) GetVirtualServer(name string) (*VirtualServer, error) {
 	var vs VirtualServer
-	fmt.Printf("check for existing vs %s", name)
+	fmt.Println("check for existing vs")
 	err, ok := b.getForEntity(&vs, uriLtm, uriVirtual, name)
 	if err != nil {
 		return nil, err

--- a/ltm.go
+++ b/ltm.go
@@ -214,7 +214,7 @@ type TcpProfile struct {
 	TailLossProbe            string `json:"tailLossProbe,omitempty"`
 	TcpOptions               string `json:"tcpOptions,omitempty"`
 	TimeWaitRecycle          string `json:"timeWaitRecycle,omitempty"`
-	TimeWaitTimeout          string `json:"timeWaitTimeout,omitempty"`
+	TimeWaitTimeout          int    `json:"timeWaitTimeout,omitempty"`
 	Timestamps               string `json:"timestamps,omitempty"`
 	VerifiedAccept           string `json:"verifiedAccept,omitempty"`
 }
@@ -943,6 +943,7 @@ type Monitors struct {
 // Monitor contains information about each individual monitor.
 type Monitor struct {
 	Name           string
+	Type           string
 	Partition      string
 	FullPath       string
 	Generation     int
@@ -1025,6 +1026,7 @@ type Profile struct {
 	Name      string `json:"name,omitempty"`
 	FullPath  string `json:"fullPath,omitempty"`
 	Partition string `json:"partition,omitempty"`
+	Type      string `json:"-"`
 	Context   string `json:"context,omitempty"`
 }
 

--- a/ltm.go
+++ b/ltm.go
@@ -1800,7 +1800,7 @@ func (b *BigIP) AddVirtualServer(config *VirtualServer) error {
 // GetVirtualServer retrieves a virtual server by name. Returns nil if the virtual server does not exist
 func (b *BigIP) GetVirtualServer(name string) (*VirtualServer, error) {
 	var vs VirtualServer
-	fmt.Printf("check for existing vs name %s \n", name)
+	fmt.Printf("check for existing vs %s", name)
 	err, ok := b.getForEntity(&vs, uriLtm, uriVirtual, name)
 	if err != nil {
 		return nil, err

--- a/ltm.go
+++ b/ltm.go
@@ -1800,7 +1800,7 @@ func (b *BigIP) AddVirtualServer(config *VirtualServer) error {
 // GetVirtualServer retrieves a virtual server by name. Returns nil if the virtual server does not exist
 func (b *BigIP) GetVirtualServer(name string) (*VirtualServer, error) {
 	var vs VirtualServer
-	fmt.Println("check for existing vs")
+	fmt.Printf("check for existing vs %s", name)
 	err, ok := b.getForEntity(&vs, uriLtm, uriVirtual, name)
 	if err != nil {
 		return nil, err

--- a/ltm_soap.go
+++ b/ltm_soap.go
@@ -36,7 +36,7 @@ type PersistenceCookie struct {
 // PersistenceCookie returns a list of oersistence profiles.
 func (b *BigIP) PersistenceCookie() (*PersistenceCookie, error) {
 	var persistenceProfiles PersistenceCookie
-	err, _ := b.getForEntity(&persistenceProfiles, uriLtm, uriPersistences)
+	err, _ := b.getForEntity(&persistenceProfiles, uriLtm, uriPersistence, uriCookie)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (b *BigIP) PersistenceCookie() (*PersistenceCookie, error) {
 // GetPersistenceCookie gets a persistence profile by name. Returns nil if the persistence profile does not exist
 func (b *BigIP) GetPersistenceCookie(name string) (*PersistenceCookie, error) {
 	var persistenceProfile PersistenceCookie
-	err, ok := b.getForEntity(&persistenceProfile, uriLtm, uriProfile, uriPersistenceCookie, name)
+	err, ok := b.getForEntity(&persistenceProfile, uriLtm, uriPersistence, uriCookie, name)
 	if err != nil {
 		return nil, err
 	}
@@ -65,23 +65,23 @@ func (b *BigIP) CreatePersistenceCookie(name string, parent string) error {
 		DefaultsFrom: parent,
 	}
 
-	return b.post(config, uriLtm, uriProfile, uriPersistenceCookie)
+	return b.post(config, uriLtm, uriPersistence, uriCookie)
 }
 
 // AddPersistenceCookie adds a new persistence profile on the BIG-IP system.
 func (b *BigIP) AddPersistenceCookie(config *PersistenceCookie) error {
-	return b.post(config, uriLtm, uriProfile, uriPersistenceCookie)
+	return b.post(config, uriLtm, uriPersistence, uriCookie)
 }
 
 // DeletePersistenceCookie removes a persistence profile.
 func (b *BigIP) DeletePersistenceCookie(name string) error {
-	return b.delete(uriLtm, uriProfile, uriPersistenceCookie, name)
+	return b.delete(uriLtm, uriPersistence, uriCookie, name)
 }
 
 // ModifyPersistenceCookie allows you to change any attribute of a persistence profile.
 // Fields that can be modified are referenced in the PersistenceCookie struct.
 func (b *BigIP) ModifyPersistenceCookie(name string, config *PersistenceCookie) error {
-	return b.put(config, uriLtm, uriProfile, uriPersistenceCookie, name)
+	return b.put(config, uriLtm, uriPersistence, uriCookie, name)
 }
 
 type PersistenceHashes struct {
@@ -115,10 +115,10 @@ type PersistenceHash struct {
 	Timeout                 string `json:"timeout,omitempty"`
 }
 
-// PersistenceHash returns a list of oersistence profiles.
+// PersistenceHash returns a list of persistence profiles.
 func (b *BigIP) PersistenceHash() (*PersistenceHash, error) {
 	var persistenceProfiles PersistenceHash
-	err, _ := b.getForEntity(&persistenceProfiles, uriLtm, uriPersistences)
+	err, _ := b.getForEntity(&persistenceProfiles, uriLtm, uriPersistence, uriHash)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (b *BigIP) PersistenceHash() (*PersistenceHash, error) {
 // GetPersistenceHash gets a persistence profile by name. Returns nil if the persistence profile does not exist
 func (b *BigIP) GetPersistenceHash(name string) (*PersistenceHash, error) {
 	var persistenceProfile PersistenceHash
-	err, ok := b.getForEntity(&persistenceProfile, uriLtm, uriProfile, uriPersistenceHash, name)
+	err, ok := b.getForEntity(&persistenceProfile, uriLtm, uriPersistence, uriHash, name)
 	if err != nil {
 		return nil, err
 	}
@@ -147,23 +147,23 @@ func (b *BigIP) CreatePersistenceHash(name string, parent string) error {
 		DefaultsFrom: parent,
 	}
 
-	return b.post(config, uriLtm, uriProfile, uriPersistenceHash)
+	return b.post(config, uriLtm, uriPersistence, uriHash)
 }
 
 // AddPersistenceHash adds a new persistence profile on the BIG-IP system.
 func (b *BigIP) AddPersistenceHash(config *PersistenceHash) error {
-	return b.post(config, uriLtm, uriProfile, uriPersistenceHash)
+	return b.post(config, uriLtm, uriPersistence, uriHash)
 }
 
 // DeletePersistenceHash removes a persistence profile.
 func (b *BigIP) DeletePersistenceHash(name string) error {
-	return b.delete(uriLtm, uriProfile, uriPersistenceHash, name)
+	return b.delete(uriLtm, uriPersistence, uriHash, name)
 }
 
 // ModifyPersistenceHash allows you to change any attribute of a persistence profile.
 // Fields that can be modified are referenced in the PersistenceHash struct.
 func (b *BigIP) ModifyPersistenceHash(name string, config *PersistenceHash) error {
-	return b.put(config, uriLtm, uriProfile, uriPersistenceHash, name)
+	return b.put(config, uriLtm, uriPersistence, uriHash, name)
 }
 
 type PersistenceSourceAddres struct {
@@ -188,10 +188,10 @@ type PersistenceSourceAddr struct {
 	Timeout                 string `json:"timeout,omitempty"`
 }
 
-// PersistenceSourceAddr returns a list of oersistence profiles.
+// PersistenceSourceAddr returns a list of persistence profiles.
 func (b *BigIP) PersistenceSourceAddr() (*PersistenceSourceAddr, error) {
 	var persistenceProfiles PersistenceSourceAddr
-	err, _ := b.getForEntity(&persistenceProfiles, uriLtm, uriPersistences)
+	err, _ := b.getForEntity(&persistenceProfiles, uriLtm, uriPersistence, uriSourceAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (b *BigIP) PersistenceSourceAddr() (*PersistenceSourceAddr, error) {
 // GetPersistenceSourceAddr gets a persistence profile by name. Returns nil if the persistence profile does not exist
 func (b *BigIP) GetPersistenceSourceAddr(name string) (*PersistenceSourceAddr, error) {
 	var persistenceProfile PersistenceSourceAddr
-	err, ok := b.getForEntity(&persistenceProfile, uriLtm, uriProfile, uriPersistenceSourceAddr, name)
+	err, ok := b.getForEntity(&persistenceProfile, uriLtm, uriPersistence, uriSourceAddr, name)
 	if err != nil {
 		return nil, err
 	}
@@ -220,21 +220,298 @@ func (b *BigIP) CreatePersistenceSourceAddr(name string, parent string) error {
 		DefaultsFrom: parent,
 	}
 
-	return b.post(config, uriLtm, uriProfile, uriPersistenceSourceAddr)
+	return b.post(config, uriLtm, uriPersistence, uriSourceAddr)
 }
 
 // AddPersistenceSourceAddr adds a new persistence profile on the BIG-IP system.
 func (b *BigIP) AddPersistenceSourceAddr(config *PersistenceSourceAddr) error {
-	return b.post(config, uriLtm, uriProfile, uriPersistenceSourceAddr)
+	return b.post(config, uriLtm, uriPersistence, uriSourceAddr)
 }
 
 // DeletePersistenceSourceAddr removes a persistence profile.
 func (b *BigIP) DeletePersistenceSourceAddr(name string) error {
-	return b.delete(uriLtm, uriProfile, uriPersistenceSourceAddr, name)
+	return b.delete(uriLtm, uriPersistence, uriSourceAddr, name)
 }
 
 // ModifyPersistenceSourceAddr allows you to change any attribute of a persistence profile.
 // Fields that can be modified are referenced in the PersistenceSourceAddr struct.
 func (b *BigIP) ModifyPersistenceSourceAddr(name string, config *PersistenceSourceAddr) error {
-	return b.put(config, uriLtm, uriProfile, uriPersistenceSourceAddr, name)
+	return b.put(config, uriLtm, uriPersistence, uriSourceAddr, name)
+}
+
+type SSLCertificateInfo struct {
+	FileName    string `json:"file_name"`
+	IsBundled   bool   `json:"is_bundled"`
+	Certificate struct {
+		CertInfo struct {
+			ID    string      `json:"id"`
+			Email interface{} `json:"email"`
+		} `json:"cert_info"`
+		ExpirationString string      `json:"expiration_string"`
+		CertType         string      `json:"cert_type"`
+		KeyType          string      `json:"key_type"`
+		Version          int         `json:"version"`
+		ExpirationDate   int         `json:"expiration_date"`
+		SerialNumber     interface{} `json:"serial_number"`
+		BitLength        int         `json:"bit_length"`
+		Issuer           struct {
+			DivisionName     string `json:"division_name"`
+			StateName        string `json:"state_name"`
+			LocalityName     string `json:"locality_name"`
+			OrganizationName string `json:"organization_name"`
+			CountryName      string `json:"country_name"`
+			CommonName       string `json:"common_name"`
+		} `json:"issuer"`
+		Subject struct {
+			DivisionName     string `json:"division_name"`
+			StateName        string `json:"state_name"`
+			LocalityName     string `json:"locality_name"`
+			OrganizationName string `json:"organization_name"`
+			CountryName      string `json:"country_name"`
+			CommonName       string `json:"common_name"`
+		} `json:"subject"`
+	} `json:"certificate"`
+}
+
+// FTPProfile represents a FTP Profile configuration
+type FTPProfile struct {
+	Kind                 string `json:"kind"`
+	Name                 string `json:"name"`
+	Partition            string `json:"partition,omitempty"`
+	FullPath             string `json:"fullPath,omitempty"`
+	Generation           int    `json:"generation,omitempty"`
+	SelfLink             string `json:"selfLink,omitempty"`
+	InheritParentProfile string `json:"inheritParentProfile,omitempty"`
+	Port                 int    `json:"port,omitempty"`
+	Security             string `json:"security,omitempty"`
+	TranslateExtended    string `json:"translateExtended,omitempty"`
+	DefaultsFrom         string `json:defaultsFrom`
+}
+
+// FTPProfiles is an array of FTPProfile structs
+type FTPProfiles []FTPProfile
+
+// FTPProfiles returns a list of FTP profiles.
+func (b *BigIP) FTPProfiles() (*FTPProfiles, error) {
+	var serverFTPProfiles FTPProfiles
+	err, _ := b.getForEntity(&serverFTPProfiles, uriLtm, uriProfile, uriFtp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &serverFTPProfiles, nil
+}
+
+// GetFTPProfile gets a FTP profile by name. Returns nil if the FTP profile does not exist
+func (b *BigIP) GetFTPProfile(name string) (*FTPProfile, error) {
+	var serverFTPProfile FTPProfile
+	err, ok := b.getForEntity(&serverFTPProfile, uriLtm, uriProfile, uriFtp, name)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	return &serverFTPProfile, nil
+}
+
+// CreateFTPProfile creates a new FTP profile on the BIG-IP system.
+func (b *BigIP) CreateFTPProfile(name string) error {
+	config := &FTPProfile{
+		Name: name,
+	}
+
+	return b.post(config, uriLtm, uriProfile, uriFtp)
+}
+
+// AddFTPProfile adds a new FTP profile on the BIG-IP system.
+func (b *BigIP) AddFTPProfile(config *FTPProfile) error {
+	return b.post(config, uriLtm, uriProfile, uriFtp)
+}
+
+// DeleteFTPProfile removes a FTP profile.
+func (b *BigIP) DeleteFTPProfile(name string) error {
+	return b.delete(uriLtm, uriProfile, uriFtp, name)
+}
+
+// ModifyFTPProfile allows you to change any attribute of a FTP profile.
+// Fields that can be modified are referenced in the VirtualServer struct.
+func (b *BigIP) ModifyFTPProfile(name string, config *FTPProfile) error {
+	return b.put(config, uriLtm, uriProfile, uriFtp, name)
+}
+
+// FastL4Profile is a representation of a fastL4Profile configuration
+type FastL4Profile struct {
+	Kind                    string `json:"kind,omitempty"`
+	Name                    string `json:"name"`
+	Partition               string `json:"partition,omitempty"`
+	FullPath                string `json:"fullPath,omitempty"`
+	Generation              int    `json:"generation,omitempty"`
+	SelfLink                string `json:"selfLink,omitempty"`
+	HardwareSynCookie       string `json:"hardwareSynCookie,omitempty"`
+	IdleTimeout             string `json:"idleTimeout,omitempty"`
+	IPTosToClient           string `json:"ipTosToClient,omitempty"`
+	IPTosToServer           string `json:"ipTosToServer,omitempty"`
+	KeepAliveInterval       string `json:"keepAliveInterval,omitempty"`
+	LinkQosToClient         string `json:"linkQosToClient,omitempty"`
+	LinkQosToServer         string `json:"linkQosToServer,omitempty"`
+	LooseClose              string `json:"looseClose,omitempty"`
+	LooseInitialization     string `json:"looseInitialization,omitempty"`
+	MssOverride             int    `json:"mssOverride,omitempty"`
+	PriorityToClient        string `json:"priorityToClient,omitempty"`
+	PriorityToServer        string `json:"priorityToServer,omitempty"`
+	PvaAcceleration         string `json:"pvaAcceleration,omitempty"`
+	PvaDynamicClientPackets int    `json:"pvaDynamicClientPackets,omitempty"`
+	PvaDynamicServerPackets int    `json:"pvaDynamicServerPackets,omitempty"`
+	PvaFlowAging            string `json:"pvaFlowAging,omitempty"`
+	PvaFlowEvict            string `json:"pvaFlowEvict,omitempty"`
+	PvaOffloadDynamic       string `json:"pvaOffloadDynamic,omitempty"`
+	PvaOffloadState         string `json:"pvaOffloadState,omitempty"`
+	ReassembleFragments     string `json:"reassembleFragments,omitempty"`
+	ReceiveWindowSize       int    `json:"receiveWindowSize,omitempty"`
+	ResetOnTimeout          string `json:"resetOnTimeout,omitempty"`
+	RttFromClient           string `json:"rttFromClient,omitempty"`
+	RttFromServer           string `json:"rttFromServer,omitempty"`
+	ServerSack              string `json:"serverSack,omitempty"`
+	ServerTimestamp         string `json:"serverTimestamp,omitempty"`
+	SoftwareSynCookie       string `json:"softwareSynCookie,omitempty"`
+	TCPCloseTimeout         string `json:"tcpCloseTimeout,omitempty"`
+	TCPGenerateIsn          string `json:"tcpGenerateIsn,omitempty"`
+	TCPHandshakeTimeout     string `json:"tcpHandshakeTimeout,omitempty"`
+	TCPStripSack            string `json:"tcpStripSack,omitempty"`
+	TCPTimestampMode        string `json:"tcpTimestampMode,omitempty"`
+	TCPWscaleMode           string `json:"tcpWscaleMode,omitempty"`
+	DefaultsFrom            string `json:"defaultsFrom"`
+}
+
+// FastL4Profiles is an array of FastL4Profile structs
+type FastL4Profiles []FastL4Profile
+
+// FastL4Profiles returns a list of fastL4 profiles.
+func (b *BigIP) FastL4Profiles() (*FastL4Profiles, error) {
+	var serverFastL4Profiles FastL4Profiles
+	err, _ := b.getForEntity(&serverFastL4Profiles, uriLtm, uriProfile, uriFastL4)
+	if err != nil {
+		return nil, err
+	}
+
+	return &serverFastL4Profiles, nil
+}
+
+// GetFastL4Profile gets a fastL4 profile by name. Returns nil if the fastL4 profile does not exist
+func (b *BigIP) GetFastL4Profile(name string) (*FastL4Profile, error) {
+	var serverFastL4Profile FastL4Profile
+	err, ok := b.getForEntity(&serverFastL4Profile, uriLtm, uriProfile, uriFastL4, name)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	return &serverFastL4Profile, nil
+}
+
+// CreateFastL4Profile creates a new fastL4 profile on the BIG-IP system.
+func (b *BigIP) CreateFastL4Profile(name string, parent string) error {
+	config := &FastL4Profile{
+		Name:         name,
+		DefaultsFrom: parent,
+	}
+
+	return b.post(config, uriLtm, uriProfile, uriFastL4)
+}
+
+// AddFastL4Profile adds a new fastL4 profile on the BIG-IP system.
+func (b *BigIP) AddFastL4Profile(config *FastL4Profile) error {
+	return b.post(config, uriLtm, uriProfile, uriFastL4)
+}
+
+// DeleteFastL4Profile removes a fastL4 profile.
+func (b *BigIP) DeleteFastL4Profile(name string) error {
+	return b.delete(uriLtm, uriProfile, uriFastL4, name)
+}
+
+// ModifyFastL4Profile allows you to change any attribute of a fastL4 profile.
+// Fields that can be modified are referenced in the VirtualServer struct.
+func (b *BigIP) ModifyFastL4Profile(name string, config *FastL4Profile) error {
+	return b.put(config, uriLtm, uriProfile, uriFastL4, name)
+}
+
+// OneConnectProfiles
+// Documentation: https://devcentral.f5.com/wiki/iControlREST.APIRef_tm_ltm_profile_oneConnect.ashx
+
+// OneConnectProfiles contains a list of every oneConnect profile on the BIG-IP system.
+type OneConnectProfiles struct {
+	OneConnectProfiles []OneConnectProfile `json:"items"`
+}
+
+// OneConnectProfile contains information about each oneConnect profile. You can use all
+// of these fields when modifying a oneConnect profile.
+type OneConnectProfile struct {
+	Kind                string `json:"kind,omitempty"`
+	Name                string `json:"name"`
+	Partition           string `json:"partition,omitempty"`
+	FullPath            string `json:"fullPath,omitempty"`
+	Generation          int    `json:"generation,omitempty"`
+	SelfLink            string `json:"selfLink,omitempty"`
+	IdleTimeoutOverride string `json:"idleTimeoutOverride,omitempty"`
+	MaxAge              int    `json:"maxAge,omitempty"`
+	MaxReuse            int    `json:"maxReuse,omitempty"`
+	MaxSize             int    `json:"maxSize,omitempty"`
+	SharePools          string `json:"sharePools,omitempty"`
+	SourceMask          string `json:"sourceMask,omitempty"`
+	DefaultsFrom        string `json:"defaultsFrom"`
+}
+
+// OneConnectProfiles returns a list of oneConnect profiles.
+func (b *BigIP) OneConnectProfiles() (*OneConnectProfiles, error) {
+	var oneConnectProfiles OneConnectProfiles
+	err, _ := b.getForEntity(&oneConnectProfiles, uriLtm, uriProfile, uriOneConnect)
+	if err != nil {
+		return nil, err
+	}
+
+	return &oneConnectProfiles, nil
+}
+
+// GetOneConnectProfile gets a oneConnect profile by name. Returns nil if the oneConnect profile does not exist
+func (b *BigIP) GetOneConnectProfile(name string) (*OneConnectProfile, error) {
+	var oneConnectProfile OneConnectProfile
+	err, ok := b.getForEntity(&oneConnectProfile, uriLtm, uriProfile, uriOneConnect, name)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	return &oneConnectProfile, nil
+}
+
+// CreateOneConnectProfile creates a new oneConnect profile on the BIG-IP system.
+func (b *BigIP) CreateOneConnectProfile(name string, parent string) error {
+	config := &OneConnectProfile{
+		Name:         name,
+		DefaultsFrom: parent,
+	}
+
+	return b.post(config, uriLtm, uriProfile, uriOneConnect)
+}
+
+// AddOneConnectProfile adds a new oneConnect profile on the BIG-IP system.
+func (b *BigIP) AddOneConnectProfile(config *OneConnectProfile) error {
+	return b.post(config, uriLtm, uriProfile, uriOneConnect)
+}
+
+// DeleteOneConnectProfile removes a oneConnect profile.
+func (b *BigIP) DeleteOneConnectProfile(name string) error {
+	return b.delete(uriLtm, uriProfile, uriOneConnect, name)
+}
+
+// ModifyOneConnectProfile allows you to change any attribute of a sever-oneConnect profile.
+// Fields that can be modified are referenced in the VirtualClient struct.
+func (b *BigIP) ModifyOneConnectProfile(name string, config *OneConnectProfile) error {
+	return b.put(config, uriLtm, uriProfile, uriOneConnect, name)
 }

--- a/shared.go
+++ b/shared.go
@@ -8,6 +8,9 @@ import (
 	"time"
 )
 
+// Debug indicates that the program should print verbose debug information
+var Debug = false
+
 const (
 	uriClientSSL       = "client-ssl"
 	uriCookie          = "cookie"

--- a/shared.go
+++ b/shared.go
@@ -10,7 +10,11 @@ import (
 
 const (
 	uriClientSSL       = "client-ssl"
+	uriCookie          = "cookie"
 	uriDatagroup       = "data-group"
+	uriFastL4          = "fastl4"
+	uriFtp             = "ftp"
+	uriHash            = "hash"
 	uriHttp            = "http"
 	uriHttpCompression = "http-compression"
 	uriIRule           = "rule"
@@ -19,6 +23,7 @@ const (
 	uriMonitor         = "monitor"
 	uriNode            = "node"
 	uriOneConnect      = "one-connect"
+	uriPersistence     = "persistence"
 	uriPolicy          = "policy"
 	uriPool            = "pool"
 	uriPoolMember      = "members"
@@ -26,6 +31,7 @@ const (
 	uriRules           = "rules"
 	uriServerSSL       = "server-ssl"
 	uriSnatPool        = "snatpool"
+	uriSourceAddr      = "source-addr"
 	uriTcp             = "tcp"
 	uriUdp             = "udp"
 	uriVirtual         = "virtual"


### PR DESCRIPTION
refactoring to use new clone of go-bigip. you must run this with the similarly named branches in the f5-soap-to-go and f5-ltm-vip-copier